### PR TITLE
Remove quote on the home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,18 +62,6 @@ description: Improve the financial privacy of yourself and others.
 		</div>
 	</section>
 
-	<section class="testimonial">
-		<div class="container flex">
-			<div class="testimonial-block">
-				<div class="square-image"><img src="https://nitter.net/pic/pbs.twimg.com%2Fprofile_images%2F1365303936731742208%2F-7h_umY2_400x400.jpg" alt="NVK" class="editable"></div>
-				<blockquote>
-					<p class="editable">Successful privacy solutions with centralized attack vectors such as a known team, domains, mixing coordinators, etc… will be taken down by governments or continue running comprised. This is why it is so important to make JoinMarkets work well for average users.</p>
-					<p class="editable author"><a href="https://nitter.net/nvk/status/1556736873715867648" target="_blank">NVK</a> - CEO of Coinkite</p>
-				</blockquote>
-			</div>
-		</div>
-	</section>
-
 	<section class="bottom-cta">
 		<h2 class="editable"><strong>Improve</strong> your financial privacy today</h2>
 		<div class="button alt"><a target="_blank" href="https://jamdocs.org/">Get Started</a></div>


### PR DESCRIPTION
I don't think it is a good idea to include a quote about the thread of government take-downs.

Privacy is a sensitive communication issue, and I think it would be helpful to have a clear stance across the site and product. We can learn from the Tor project. For example, they have an [abuse FAQ](https://support.torproject.org/abuse/), which includes this line:

> We hate that there are some people who use Tor for nefarious purposes, and we condemn the misuse and exploitation of our technology for criminal activity. It's essential to understand that criminal intent lies with the individuals and not the tools they use.

The Tor [history/about page](https://www.torproject.org/about/history/) also does a good job at outlining the mission.

Probably a bigger discussion to be had, but for starters I think it might be a good idea to just remove that quote.